### PR TITLE
Fix binding for daily expense list

### DIFF
--- a/WalletLog/Models/Implementations/DailySet.cs
+++ b/WalletLog/Models/Implementations/DailySet.cs
@@ -14,7 +14,8 @@ namespace WalletLog.Models
 {
     public class DailySet
     {
-        public ObservableCollection<ExpenseItem> DailyExpenseItems = new ObservableCollection<ExpenseItem>();
+        // ItemsSourceからバインドできるようプロパティとして公開する
+        public ObservableCollection<ExpenseItem> DailyExpenseItems { get; } = new ObservableCollection<ExpenseItem>();
         public DateTime? CurrentDate { get; set; }
 
         public void Clear()


### PR DESCRIPTION
## Summary
- expose `DailyExpenseItems` as a property so WPF bindings work

## Testing
- `dotnet build WalletLog.sln -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d466fee548333b649cb9dc51a65da